### PR TITLE
refactor: rename apt.yml workflow to build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Publish APT Package
+name: Build Debian Package
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
   #   types: [published]
 
 jobs:
-  apt:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This PR renames the apt.yml workflow file to build.yml to better reflect its purpose, and also updates the job name from 'apt' to 'build' for consistency.

This is a small, discrete change that prepares for future enhancements to the PPA publishing workflow.