### PR TITLE
feat: add PPA publishing workflow for Launchpad

### DIFF
--- a/.github/workflows/publish-ppa.yml
+++ b/.github/workflows/publish-ppa.yml
@@ -83,9 +83,7 @@ jobs:
           repository: "atxtechbro/siphon"
           gpg_private_key: ${{ secrets.APT_GPG_PRIVATE_KEY }}
           gpg_passphrase: ${{ secrets.APT_GPG_PASSPHRASE }}
-          tarball: "../siphon_0.1.0.orig.tar.gz"
-          debian_dir: "./debian"
+          pkgdir: "."
           series: "jammy"
           extra_series: "focal noble"
-          deb_email: "morganj2k@gmail.com"
-          deb_fullname: "Morgan Joyce"
+          is_native: "false"

--- a/.github/workflows/publish-ppa.yml
+++ b/.github/workflows/publish-ppa.yml
@@ -64,14 +64,18 @@ jobs:
           
       - name: Create tarball for PPA
         run: |
-          # Create a tarball from the source code
+          # Create a clean directory structure for the tarball
           mkdir -p /tmp/siphon-build/siphon-0.1.0
-          cp -r * /tmp/siphon-build/siphon-0.1.0/ 2>/dev/null || true
+          # Copy all files except excluded ones
+          rsync -av --exclude='.git' --exclude='debian' --exclude='artifacts' . /tmp/siphon-build/siphon-0.1.0/
+          # Create the tarball
           cd /tmp/siphon-build
           TARBALL_NAME="siphon_0.1.0.orig.tar.gz"
-          tar -czf $TARBALL_NAME siphon-0.1.0 --exclude=.git --exclude=debian
+          tar -czf $TARBALL_NAME siphon-0.1.0
+          # Copy to parent directory as required by the action
           cp $TARBALL_NAME $GITHUB_WORKSPACE/../
           echo "Created tarball: $TARBALL_NAME at $(readlink -f $GITHUB_WORKSPACE/../$TARBALL_NAME)"
+          ls -la $GITHUB_WORKSPACE/../$TARBALL_NAME
           
       - name: Publish to Launchpad PPA
         uses: yuezk/publish-ppa-package@v1

--- a/.github/workflows/publish-ppa.yml
+++ b/.github/workflows/publish-ppa.yml
@@ -76,22 +76,27 @@ jobs:
           cp siphon_0.1.0.orig.tar.gz $GITHUB_WORKSPACE/../
           cp siphon-0.1.0.tar.gz $GITHUB_WORKSPACE/../
           
-          # Also copy to the /github directory as required by the action
-          mkdir -p /github
-          cp siphon-0.1.0.tar.gz /github/
-          
           echo "Created tarballs:"
           echo " - $(readlink -f $GITHUB_WORKSPACE/../siphon_0.1.0.orig.tar.gz)"
           echo " - $(readlink -f $GITHUB_WORKSPACE/../siphon-0.1.0.tar.gz)"
-          echo " - /github/siphon-0.1.0.tar.gz"
           
-      - name: Publish to Launchpad PPA
-        uses: yuezk/publish-ppa-package@v1
-        with:
-          repository: "atxtechbro/siphon"
-          gpg_private_key: ${{ secrets.APT_GPG_PRIVATE_KEY }}
-          gpg_passphrase: ${{ secrets.APT_GPG_PASSPHRASE }}
-          pkgdir: "."
-          series: "jammy"
-          extra_series: "focal noble"
-          is_native: "false"
+      - name: Verify PPA setup (test only)
+        run: |
+          echo "Verification successful!"
+          echo "PPA publishing would be done using:"
+          echo "- Repository: atxtechbro/siphon"
+          echo "- GPG signing: Available"
+          echo "- Base directory: $(pwd)"
+          echo "- Series: jammy focal noble"
+          echo "- Native package: false"
+          
+          echo "To implement in production, use:"
+          echo "uses: yuezk/publish-ppa-package@v1"
+          echo "with:"
+          echo "  repository: \"atxtechbro/siphon\""
+          echo "  gpg_private_key: \${{ secrets.APT_GPG_PRIVATE_KEY }}"
+          echo "  gpg_passphrase: \${{ secrets.APT_GPG_PASSPHRASE }}"
+          echo "  pkgdir: \".\""
+          echo "  series: \"jammy\""
+          echo "  extra_series: \"focal noble\""
+          echo "  is_native: \"false\""

--- a/.github/workflows/publish-ppa.yml
+++ b/.github/workflows/publish-ppa.yml
@@ -6,23 +6,24 @@ on:
     workflows: ["Build Debian Package"]
     types:
       - completed
-    tags:
-      - 'v*'
   
-  # For testing the workflow on this PR branch
+  # For direct tag pushes or testing on the PR branch
   push:
     branches:
       - feat/launchpad-ppa-publishing
+    tags:
+      - 'v*'
 
 jobs:
   publish-ppa:
-    # Run on successful build workflow for version tags OR on direct pushes to PR branch
+    # Run on successful build workflow for version tags OR on direct pushes to PR branch OR on tag pushes
     if: |
       (github.event_name == 'workflow_run' && 
        github.event.workflow_run.conclusion == 'success' && 
        startsWith(github.event.workflow_run.head_branch, 'v')) || 
       (github.event_name == 'push' && 
-       github.ref == 'refs/heads/feat/launchpad-ppa-publishing')
+       (github.ref == 'refs/heads/feat/launchpad-ppa-publishing' || 
+        startsWith(github.ref, 'refs/tags/v')))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -80,23 +81,13 @@ jobs:
           echo " - $(readlink -f $GITHUB_WORKSPACE/../siphon_0.1.0.orig.tar.gz)"
           echo " - $(readlink -f $GITHUB_WORKSPACE/../siphon-0.1.0.tar.gz)"
           
-      - name: Verify PPA setup (test only)
-        run: |
-          echo "Verification successful!"
-          echo "PPA publishing would be done using:"
-          echo "- Repository: atxtechbro/siphon"
-          echo "- GPG signing: Available"
-          echo "- Base directory: $(pwd)"
-          echo "- Series: jammy focal noble"
-          echo "- Native package: false"
-          
-          echo "To implement in production, use:"
-          echo "uses: yuezk/publish-ppa-package@v1"
-          echo "with:"
-          echo "  repository: \"atxtechbro/siphon\""
-          echo "  gpg_private_key: \${{ secrets.APT_GPG_PRIVATE_KEY }}"
-          echo "  gpg_passphrase: \${{ secrets.APT_GPG_PASSPHRASE }}"
-          echo "  pkgdir: \".\""
-          echo "  series: \"jammy\""
-          echo "  extra_series: \"focal noble\""
-          echo "  is_native: \"false\""
+      - name: Publish to Launchpad PPA
+        uses: yuezk/publish-ppa-package@v1
+        with:
+          repository: "atxtechbro/siphon"
+          gpg_private_key: ${{ secrets.APT_GPG_PRIVATE_KEY }}
+          gpg_passphrase: ${{ secrets.APT_GPG_PASSPHRASE }}
+          pkgdir: "."
+          series: "jammy"
+          extra_series: "focal noble"
+          is_native: "false"

--- a/.github/workflows/publish-ppa.yml
+++ b/.github/workflows/publish-ppa.yml
@@ -65,10 +65,13 @@ jobs:
       - name: Create tarball for PPA
         run: |
           # Create a tarball from the source code
+          mkdir -p /tmp/siphon-build/siphon-0.1.0
+          cp -r * /tmp/siphon-build/siphon-0.1.0/ 2>/dev/null || true
+          cd /tmp/siphon-build
           TARBALL_NAME="siphon_0.1.0.orig.tar.gz"
-          tar -czf $TARBALL_NAME --exclude=.git --exclude=debian --transform 's,^,siphon-0.1.0/,' .
-          mv $TARBALL_NAME ../
-          echo "Created tarball: $TARBALL_NAME"
+          tar -czf $TARBALL_NAME siphon-0.1.0 --exclude=.git --exclude=debian
+          cp $TARBALL_NAME $GITHUB_WORKSPACE/../
+          echo "Created tarball: $TARBALL_NAME at $(readlink -f $GITHUB_WORKSPACE/../$TARBALL_NAME)"
           
       - name: Publish to Launchpad PPA
         uses: yuezk/publish-ppa-package@v1

--- a/.github/workflows/publish-ppa.yml
+++ b/.github/workflows/publish-ppa.yml
@@ -1,0 +1,48 @@
+name: Publish to Launchpad PPA
+
+on:
+  workflow_run:
+    workflows: ["Build Debian Package"]
+    types:
+      - completed
+
+jobs:
+  publish-ppa:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download build artifacts
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build.yml
+          workflow_conclusion: success
+          name: debian-package
+          path: ./artifacts
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y debmake build-essential devscripts debhelper-compat dh-python python3-all
+
+      # For PPA publishing, we need source packages, not binary packages
+      - name: Build source package for PPA
+        run: |
+          # Build source package for PPA upload
+          debuild -S -sa -us -uc
+        working-directory: .
+
+      - name: List source files
+        run: |
+          find ../ -name "siphon_*.changes" -type f
+          
+      - name: Publish to Launchpad PPA
+        uses: yuezk/publish-ppa-package@v1
+        with:
+          source_file: $(find ../ -name "siphon_*.changes" -type f | grep -v "binary" | head -1)
+          gpg_private_key: ${{ secrets.APT_GPG_PRIVATE_KEY }}
+          gpg_passphrase: ${{ secrets.APT_GPG_PASSPHRASE }}
+          ppa_repo: ppa:atxtechbro/siphon
+          ubuntu_series: jammy focal noble

--- a/.github/workflows/publish-ppa.yml
+++ b/.github/workflows/publish-ppa.yml
@@ -62,11 +62,23 @@ jobs:
           SOURCE_FILE=$(find ../ -name "siphon_*.changes" -type f | grep -v "binary" | head -1 || echo "NO_SOURCE_FILE_FOUND")
           echo $SOURCE_FILE
           
+      - name: Create tarball for PPA
+        run: |
+          # Create a tarball from the source code
+          TARBALL_NAME="siphon_0.1.0.orig.tar.gz"
+          tar -czf $TARBALL_NAME --exclude=.git --exclude=debian --transform 's,^,siphon-0.1.0/,' .
+          mv $TARBALL_NAME ../
+          echo "Created tarball: $TARBALL_NAME"
+          
       - name: Publish to Launchpad PPA
         uses: yuezk/publish-ppa-package@v1
         with:
-          source_file: $(find ../ -name "siphon_*.changes" -type f | grep -v "binary" | head -1)
+          repository: "atxtechbro/siphon"
           gpg_private_key: ${{ secrets.APT_GPG_PRIVATE_KEY }}
           gpg_passphrase: ${{ secrets.APT_GPG_PASSPHRASE }}
-          ppa_repo: ppa:atxtechbro/siphon
-          ubuntu_series: jammy focal noble
+          tarball: "../siphon_0.1.0.orig.tar.gz"
+          debian_dir: "./debian"
+          series: "jammy"
+          extra_series: "focal noble"
+          deb_email: "morganj2k@gmail.com"
+          deb_fullname: "Morgan Joyce"

--- a/.github/workflows/publish-ppa.yml
+++ b/.github/workflows/publish-ppa.yml
@@ -1,14 +1,28 @@
 name: Publish to Launchpad PPA
 
 on:
+  # For production use with tags
   workflow_run:
     workflows: ["Build Debian Package"]
     types:
       - completed
+    tags:
+      - 'v*'
+  
+  # For testing the workflow on this PR branch
+  push:
+    branches:
+      - feat/launchpad-ppa-publishing
 
 jobs:
   publish-ppa:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v') }}
+    # Run on successful build workflow for version tags OR on direct pushes to PR branch
+    if: |
+      (github.event_name == 'workflow_run' && 
+       github.event.workflow_run.conclusion == 'success' && 
+       startsWith(github.event.workflow_run.head_branch, 'v')) || 
+      (github.event_name == 'push' && 
+       github.ref == 'refs/heads/feat/launchpad-ppa-publishing')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -21,6 +35,11 @@ jobs:
           workflow_conclusion: success
           name: debian-package
           path: ./artifacts
+          
+      - name: List downloaded artifacts
+        run: |
+          echo "Contents of artifacts directory:"
+          ls -la ./artifacts
 
       - name: Install Dependencies
         run: |
@@ -31,12 +50,17 @@ jobs:
       - name: Build source package for PPA
         run: |
           # Build source package for PPA upload
+          # Using -us -uc for now, the action will handle signing
           debuild -S -sa -us -uc
         working-directory: .
 
       - name: List source files
         run: |
-          find ../ -name "siphon_*.changes" -type f
+          echo "Generated source files:"
+          find ../ -name "siphon_*" -type f
+          echo "Source changes file to be published:"
+          SOURCE_FILE=$(find ../ -name "siphon_*.changes" -type f | grep -v "binary" | head -1 || echo "NO_SOURCE_FILE_FOUND")
+          echo $SOURCE_FILE
           
       - name: Publish to Launchpad PPA
         uses: yuezk/publish-ppa-package@v1

--- a/.github/workflows/publish-ppa.yml
+++ b/.github/workflows/publish-ppa.yml
@@ -68,14 +68,22 @@ jobs:
           mkdir -p /tmp/siphon-build/siphon-0.1.0
           # Copy all files except excluded ones
           rsync -av --exclude='.git' --exclude='debian' --exclude='artifacts' . /tmp/siphon-build/siphon-0.1.0/
-          # Create the tarball
+          # Create the tarball in BOTH required formats
           cd /tmp/siphon-build
-          TARBALL_NAME="siphon_0.1.0.orig.tar.gz"
-          tar -czf $TARBALL_NAME siphon-0.1.0
+          tar -czf siphon_0.1.0.orig.tar.gz siphon-0.1.0
+          tar -czf siphon-0.1.0.tar.gz siphon-0.1.0
           # Copy to parent directory as required by the action
-          cp $TARBALL_NAME $GITHUB_WORKSPACE/../
-          echo "Created tarball: $TARBALL_NAME at $(readlink -f $GITHUB_WORKSPACE/../$TARBALL_NAME)"
-          ls -la $GITHUB_WORKSPACE/../$TARBALL_NAME
+          cp siphon_0.1.0.orig.tar.gz $GITHUB_WORKSPACE/../
+          cp siphon-0.1.0.tar.gz $GITHUB_WORKSPACE/../
+          
+          # Also copy to the /github directory as required by the action
+          mkdir -p /github
+          cp siphon-0.1.0.tar.gz /github/
+          
+          echo "Created tarballs:"
+          echo " - $(readlink -f $GITHUB_WORKSPACE/../siphon_0.1.0.orig.tar.gz)"
+          echo " - $(readlink -f $GITHUB_WORKSPACE/../siphon-0.1.0.tar.gz)"
+          echo " - /github/siphon-0.1.0.tar.gz"
           
       - name: Publish to Launchpad PPA
         uses: yuezk/publish-ppa-package@v1

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-siphon (0.1.0) unstable; urgency=medium
+siphon (0.1.0-1~ppa1~ubuntu20.04.1) focal; urgency=medium
 
-  * Initial release.
+  * Initial release for Ubuntu PPA.
 
- -- Morgan Joyce <morganj2k@gmail.com>  Wed, 26 Mar 2025 12:00:00 +0000
+ -- Morgan Joyce <morganj2k@gmail.com>  Fri, 29 Mar 2025 02:23:00 +0000


### PR DESCRIPTION
This PR adds a new GitHub Actions workflow to publish the package to Launchpad PPA.

Features:
- Adds a workflow that runs after the build workflow completes successfully
- For tagged releases with 'v*' pattern, will automatically publish to Launchpad PPA
- Configures for publishing to multiple Ubuntu series (jammy, focal, noble)
- Updates debian/changelog to have proper format for Ubuntu PPA
- Creates the necessary source package files for PPA publishing

Progress:
- [x] Workflow successfully downloads artifacts from build job
- [x] Workflow correctly builds source package
- [x] Workflow creates the required tarballs
- [ ] Fix tarball location issue (see #18)
- [ ] Test actual PPA upload
- [ ] Merge to main after successful PPA upload

The workflow is functional up to the PPA upload step. Issue #18 tracks the remaining work needed for a successful upload.