### PR TITLE
fix: update GitHub Pages workflow to use compatible action versions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: './site'
+          path: 'site'
       
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
This PR fixes the GitHub Pages workflow by ensuring all action versions are compatible with each other.\n\nChanges:\n- Updated path from './site' to 'site' (removing the leading ./ which might be causing issues)\n- Changed deploy-pages from v2 to v1 to match the upload-pages-artifact version\n\nThe error was:\n\n\nThis change should resolve the GitHub Pages deployment failures.