### PR TITLE
fix: replace upload-pages-artifact with direct API calls

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -44,9 +44,34 @@ jobs:
         uses: actions/configure-pages@v3
       
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
-        with:
-          path: 'site'
+        run: |
+          # Create artifact directory
+          mkdir -p /tmp/artifact
+          
+          # Copy site contents to artifact directory
+          cp -r site/* /tmp/artifact/
+          
+          # Create artifact
+          cd /tmp/artifact
+          tar --dereference --hard-dereference --directory . -cf "$RUNNER_TEMP/artifact.tar" .
+          
+          # Upload artifact
+          echo "::group::Upload artifact"
+          ARTIFACT_ID=$(curl -s -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${{ github.repository }}/pages/artifacts" \
+            | jq -r '.id')
+          
+          curl -s -X PUT \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ github.token }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Content-Type: application/x-tar" \
+            --data-binary "@$RUNNER_TEMP/artifact.tar" \
+            "https://uploads.github.com/repos/${{ github.repository }}/pages/artifacts/$ARTIFACT_ID"
+          echo "::endgroup::"
       
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
This PR fixes the GitHub Pages workflow by replacing the problematic  action with direct GitHub API calls to upload the artifact.\n\nThe error was:\n\n\nThis appears to be caused by a dependency issue between the GitHub Pages actions. By using direct API calls instead of the action, we bypass this dependency issue completely.\n\nThe new approach:\n1. Creates a tar archive of the site directory\n2. Uses GitHub API to create and upload the artifact\n3. Uses the deploy-pages@v1 action to deploy the uploaded artifact\n\nThis should resolve the GitHub Pages deployment failures once and for all.